### PR TITLE
Add note on custom Safari AutoFill password rules

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -821,6 +821,9 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
         <li>
           <small>Using <code translate="no">&lt;input type="password"&gt;</code> needs to also have <code translate="no">spellcheck="false"</code> declared on it to <a rel="external noopener" href="https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords">avoid a security risk</a>.</code></small>
         </li>
+        <li>
+          <small>Safari's password AutoFill feature can be <a rel="external noopener" href="https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules">configured with custom password criteria</a>.</small>
+        </li>
       </ul>
     </fieldset>
     <!-- End of #subsection-text-input -->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "accessible-html-content-patterns",
   "description": "A collection of the full HTML5 Doctor Element Index as well as common markup patterns for quick reference.",
   "homepage": "https://github.com/ericwbailey/accessible-html-content-patterns",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "author": "Eric Bailey <eric.w.bailey@gmail.com> (http://ericwbailey.design/)",
   "contributors": "Scott Doxey <hello@scottdoxey.com> (https://www.scottdoxey.com/)",

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -83,6 +83,9 @@
         <li>
           <small>Using <code translate="no">&lt;input type="password"&gt;</code> needs to also have <code translate="no">spellcheck="false"</code> declared on it to <a rel="external noopener" href="https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords">avoid a security risk</a>.</code></small>
         </li>
+        <li>
+          <small>Safari's password AutoFill feature can be <a rel="external noopener" href="https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules">configured with custom password criteria</a>.</small>
+        </li>
       </ul>
     </fieldset>
     <!-- End of #subsection-text-input -->


### PR DESCRIPTION
This PR adds a bullet point note about [custom Safari AutoFill password rules](https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules).