### PR TITLE
Add note on sharing `iframe` content with third-party websites

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -631,6 +631,10 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
     title="Example blank iframe"
     name="iframe">
   </iframe>
+  <h4 id="notes-iframe">Notes:</h4>
+  <p>
+    <small>Use the <code translate="no">allow=&quot;web-share&quot;</code> declaration to <a rel="external noopener" href="https://www.webkit.org/blog/13708/allowing-web-share-on-third-party-sites/">enable sharing of <code translate="no">&lt;iframe&gt;</code> content via the Web Share API</a> on third-party sites.</small>
+  </p>
   <!-- End of #subsection-iframe -->
 
   <!-- Start of #subsection-audio -->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "accessible-html-content-patterns",
   "description": "A collection of the full HTML5 Doctor Element Index as well as common markup patterns for quick reference.",
   "homepage": "https://github.com/ericwbailey/accessible-html-content-patterns",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "author": "Eric Bailey <eric.w.bailey@gmail.com> (http://ericwbailey.design/)",
   "contributors": "Scott Doxey <hello@scottdoxey.com> (https://www.scottdoxey.com/)",

--- a/partials/section.embedded.hbs
+++ b/partials/section.embedded.hbs
@@ -110,6 +110,10 @@
     title="Example blank iframe"
     name="iframe">
   </iframe>
+  <h4 id="notes-iframe">Notes:</h4>
+  <p>
+    <small>Use the <code translate="no">allow=&quot;web-share&quot;</code> declaration to <a rel="external noopener" href="https://www.webkit.org/blog/13708/allowing-web-share-on-third-party-sites/">enable sharing of <code translate="no">&lt;iframe&gt;</code> content via the Web Share API</a> on third-party sites.</small>
+  </p>
   <!-- End of #subsection-iframe -->
 
   <!-- Start of #subsection-audio -->


### PR DESCRIPTION
This PR adds a note about using `allow="web-share"` on [`iframe` elements for Web Share API support](https://www.webkit.org/blog/13708/allowing-web-share-on-third-party-sites/).