### PR TITLE
Add `<search>` and `dir=auto` to input examples with reference note

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -751,28 +751,30 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
       </legend>
 
       <label for="input-text">Text</label>
-      <input id="input-text" name="text" type="text" />
+      <input id="input-text" name="text" dir="auto" type="text" />
 
       <label for="input-text-with-placeholder">Text with Placeholder</label>
-      <input id="input-text-with-placeholder" name="placeholder" placeholder="Placeholder" type="text" />
+      <input id="input-text-with-placeholder" name="placeholder" placeholder="Placeholder" dir="auto" type="text" />
 
       <label for="input-email">Email</label>
-      <input id="input-email" name="email" placeholder="name@example.com" autocapitalize="off" autocorrect="off" spellcheck="false" type="email" />
+      <input id="input-email" name="email" placeholder="name@example.com" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="email" />
 
       <label for="input-password">Password</label>
-      <input id="input-password" name="password" autocapitalize="off" autocorrect="off" spellcheck="false" type="password" />
+      <input id="input-password" name="password" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="password" />
 
       <label for="input-url">URL</label>
-      <input id="input-url" name="url" autocapitalize="off" spellcheck="false" type="url" />
+      <input id="input-url" name="url" autocapitalize="off" spellcheck="false" dir="auto" type="url" />
 
       <label for="input-telephone">Telephone</label>
-      <input id="input-telephone" name="telephone" autocorrect="off" autocomplete="tel" spellcheck="false" type="tel" />
+      <input id="input-telephone" name="telephone" autocorrect="off" autocomplete="tel" spellcheck="false" dir="auto" type="tel" />
 
       <label for="input-number" >Number</label>
-      <input id="input-number" type="text" inputmode="numeric" pattern="[0-9]*" />
+      <input id="input-number" type="text" inputmode="numeric" dir="auto" pattern="[0-9]*" />
 
-      <label for="input-search">Search</label>
-      <input id="input-search" name="search" spellcheck="false" type="search" />
+      <search>
+        <label for="input-search">Search</label>
+        <input id="input-search" name="search" spellcheck="false" dir="auto" type="search" />
+      </search>
 
       <label for="input-date">Date</label>
       <input id="input-date" name="date" type="date" />
@@ -790,7 +792,7 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
       <input id="input-week" name="week" type="week" />
 
       <label for="input-datalist">Datalist</label>
-      <input list="dog-breeds" id="input-datalist" name="datalist" type="text">
+      <input list="dog-breeds" id="input-datalist" name="datalist" dir="auto" type="text">
       <datalist id="dog-breeds">
         <option value="Beagles"></option>
         <option value="Boxers"></option>
@@ -813,6 +815,9 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
 
       <h4 id="notes-text-input">Notes:</h4>
       <ul>
+        <li>
+          <small>Add <code translate="no">dir="auto"</code> to <a rel="external noopener" href="https://mough.xyz/312/psa-add-dir-auto-to-your-inputs-and-textareas">inputs that accept text</a>.</small>
+        </li>
         <li>
           <small>Avoid nesting <code translate="no">input</code> elements inside of <code translate="no">label</code> elements for better support for <a rel="external noopener" href="https://www.nuance.com/dragon.html">Dragon Speech Recognition</a>.</small>
         </li>
@@ -1074,37 +1079,39 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
         <h4 id="subtitle-input">Input</h4>
 
         <label for="input-required">Required</label>
-        <input required id="input-required" name="required" type="text" />
+        <input required id="input-required" name="required" dir="auto" type="text" />
 
         <label for="input-readonly">Readonly</label>
-        <input readonly value="Read Only" id="input-readonly" name="readonly" type="text" />
+        <input readonly value="Read Only" id="input-readonly" name="readonly" dir="auto" type="text" />
 
         <label for="input-loading">Loading</label>
-        <input id="input-loading" name="loading" aria-busy="true" data-input-state="loading" type="text" />
+        <input id="input-loading" name="loading" aria-busy="true" data-input-state="loading" dir="auto" type="text" />
 
         <label for="input-disabled">Disabled</label>
-        <input disabled id="input-disabled" name="disabled" type="text" />
+        <input disabled id="input-disabled" name="disabled" dir="auto" type="text" />
 
         <label for="input-valid">Valid</label>
-        <input id="input-valid" name="valid" aria-invalid="false" type="text" />
+        <input id="input-valid" name="valid" aria-invalid="false" dir="auto" type="text" />
 
         <label for="input-invalid">Invalid</label>
-        <input id="input-invalid" name="invalid" aria-invalid="true" type="text" />
+        <input id="input-invalid" name="invalid" aria-invalid="true" dir="auto" type="text" />
 
         <label for="input-warning">Warning</label>
-        <input id="input-warning" name="warning" data-input-state="warning" type="text" />
+        <input id="input-warning" name="warning" data-input-state="warning" dir="auto" type="text" />
 
-        <label for="input-search-with-autosave">Search with Autosave</label>
-        <input autosave id="input-search-with-autosave" name="search-with-autosave" type="search" />
+        <search>
+          <label for="input-search-with-autosave">Search with Autosave</label>
+          <input autosave id="input-search-with-autosave" name="search-with-autosave" dir="auto" type="search" />
+        </search>
 
         <label for="input-pattern">Input with Pattern Validation</label>
-        <input pattern="[0-9]{13,16}" id="input-pattern" name="pattern" type="number" />
+        <input pattern="[0-9]{13,16}" id="input-pattern" name="pattern" dir="auto" type="number" />
 
         <label for="input-minlength">Minlength</label>
-        <input id="input-minlength" name="minlength" minlength="5" type="number" />
+        <input id="input-minlength" name="minlength" minlength="5" dir="auto" type="number" />
 
         <label for="input-maxlength">Maxlength</label>
-        <input id="input-maxlength" name="maxlength" maxlength="10" type="number" />
+        <input id="input-maxlength" name="maxlength" maxlength="10" dir="auto" type="number" />
       </div>
       <!-- End of #subsection-input -->
 
@@ -1120,9 +1127,14 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
         </button>
 
         <h5 id="notes-button-states-and-validation">Notes:</h5>
-        <p>
-          <small>Use <code translate="no">:hover</code>, <code translate="no">:focus</code>, and <code translate="no">:active</code> selectors to control the other button states. Learn more about <a rel="external noopener" href="https://css-tricks.com/user-facing-state/">semantically managing state</a> and using <a rel="external noopener" href="https://medium.com/eightshapes-llc/buttons-in-design-systems-eac3acf7e23#.b1p96hsrw"><cite>Buttons in Design Systems</cite></a>.</small>
-        </p>
+        <ul>
+          <li>
+            <small>Use <code translate="no">:hover</code>, <code translate="no">:focus</code>, and <code translate="no">:active</code> selectors to control the other button states. Learn more about <a rel="external noopener" href="https://css-tricks.com/user-facing-state/">semantically managing state</a> and using <a rel="external noopener" href="https://medium.com/eightshapes-llc/buttons-in-design-systems-eac3acf7e23#.b1p96hsrw"><cite>Buttons in Design Systems</cite></a>.</small>
+          </li>
+          <li>
+            <small>Other <a rel="external noopener" href="https://ericwbailey.website/published/all-the-user-facing-states/">user-facing states</a> may also apply.</small>
+          </li>
+        </ul>
       </div>
       <!-- End of #subsection-button-states -->
     </fieldset>
@@ -1135,124 +1147,123 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
       </legend>
 
       <label for="input-autocomplete-on">On (Browser automatically completes)</label>
-      <input id="input-autocomplete-on" name="autocomplete-on" autocomplete="on" type="text" />
+      <input id="input-autocomplete-on" name="autocomplete-on" autocomplete="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-name">Name (Full name)</label>
-      <input id="input-autocomplete-name" name="autocomplete-name" autocomplete="name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-name" name="autocomplete-name" autocomplete="name" autocorrect="off" dir="auto" type="text" />
 
 
       <label for="input-autocomplete-honorific-prefix">Honorific Prefix (Mr., Ms., Dr., etc.)</label>
-      <input id="input-autocomplete-honorific-prefix" name="autocomplete-honorific-prefix" autocomplete="honorific-prefix" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-honorific-prefix" name="autocomplete-honorific-prefix" autocomplete="honorific-prefix" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-additional-name">Additional Name</label>
-      <input id="input-autocomplete-additional-name" name="autocomplete-additional-name" autocomplete="additional-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-additional-name" name="autocomplete-additional-name" autocomplete="additional-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-family-name">Family Name</label>
-      <input id="input-autocomplete-family-name" name="autocomplete-family-name" autocomplete="family-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-family-name" name="autocomplete-family-name" autocomplete="family-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-honorific-suffix">Honorific Suffix (Jr., II, etc.)</label>
-      <input id="input-autocomplete-honorific-suffix" name="autocomplete-honorific-suffix" autocomplete="honorific-suffix" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-honorific-suffix" name="autocomplete-honorific-suffix" autocomplete="honorific-suffix" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-nickname">Nickname</label>
-      <input id="input-autocomplete-nickname" name="autocomplete-nickname" autocomplete="nickname" autocorrect="off" type="text" />
+      <input id="input-autocomplete-nickname" name="autocomplete-nickname" autocomplete="nickname" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-email">Autocomplete Email</label>
-      <input id="input-autocomplete-email" name="autocomplete-email" autocomplete="email" autocapitalize="off" autocorrect="off" spellcheck="false" type="text" />
+      <input id="input-autocomplete-email" name="autocomplete-email" autocomplete="email" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="text" />
 
       <label for="input-autocomplete-username">Username</label>
-      <input id="input-autocomplete-username" name="autocomplete-username" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" type="text" />
+      <input id="input-autocomplete-username" name="autocomplete-username" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="text" />
 
       <label for="input-autocomplete-new-password">New Password</label>
-      <input id="input-autocomplete-new-password" name="autocomplete-new-password" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false" type="text" />
+      <input id="input-autocomplete-new-password" name="autocomplete-new-password" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="text" />
 
       <label for="input-autocomplete-current-password">Current Password</label>
-      <input id="input-autocomplete-current-password" name="autocomplete-current-password" autocomplete="current-password" autocapitalize="off" autocorrect="off" spellcheck="false" type="text" />
+      <input id="input-autocomplete-current-password" name="autocomplete-current-password" autocomplete="current-password" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="text" />
 
       <label for="input-autocomplete-organization-title">Organization Title</label>
-      <input id="input-autocomplete-organization-title" name="autocomplete-organization-title" autocomplete="organization-title" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-organization-title" name="autocomplete-organization-title" autocomplete="organization-title" autocapitalize="on" dir="auto" type="text" />
 
 
       <label for="input-autocomplete-organization">Organization</label>
-      <input id="input-autocomplete-organization" name="autocomplete-organization" autocomplete="organization" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-organization" name="autocomplete-organization" autocomplete="organization" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-street-address">Street Address</label>
-      <input id="input-autocomplete-street-address" name="autocomplete-street-address" autocomplete="shipping street-address" autocorrect="off" type="text" />
+      <input id="input-autocomplete-street-address" name="autocomplete-street-address" autocomplete="shipping street-address" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-address-line1">Address Line 1 (Can use address-line1-3)</label>
-      <input id="input-autocomplete-address-line1" name="autocomplete-address-line1" autocomplete="address-line1" autocorrect="off" type="text" />
+      <input id="input-autocomplete-address-line1" name="autocomplete-address-line1" autocomplete="address-line1" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-address-level4">Address Level 4 (Can use address-level4-1)</label>
-      <input id="input-autocomplete-address-level4" name="autocomplete-address-level4" autocomplete="address-level4" autocorrect="off" type="text" />
+      <input id="input-autocomplete-address-level4" name="autocomplete-address-level4" autocomplete="address-level4" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-country">Country</label>
-      <input id="input-autocomplete-country" name="autocomplete-country" autocomplete="country" type="text" />
+      <input id="input-autocomplete-country" name="autocomplete-country" autocomplete="country" dir="auto" type="text" />
 
       <label for="input-autocomplete-country-name">Country Name</label>
-      <input id="input-autocomplete-country-name" name="autocomplete-country-name" autocomplete="country-name" type="text" />
-
+      <input id="input-autocomplete-country-name" name="autocomplete-country-name" autocomplete="country-name" dir="auto" type="text" />
 
       <label for="input-autocomplete-postal-code">Postal Code</label>
-      <input novalidate id="input-autocomplete-postal-code" name="autocomplete-postal-code" autocomplete="shipping postal-code" autocorrect="off" type="number" />
+      <input novalidate id="input-autocomplete-postal-code" name="autocomplete-postal-code" autocomplete="shipping postal-code" autocorrect="off" dir="auto" type="number" />
 
       <label for="input-autocomplete-cc-name">CC Name (Full name as given on the payment instrument)</label>
-      <input id="input-autocomplete-cc-name" name="autocomplete-cc-name" autocomplete="cc-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-cc-name" name="autocomplete-cc-name" autocomplete="cc-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-cc-given-name">CC Given Name</label>
-      <input id="input-autocomplete-cc-given-name" name="autocomplete-cc-given-name" autocomplete="cc-given-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-cc-given-name" name="autocomplete-cc-given-name" autocomplete="cc-given-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-cc-additional-name">CC Additional Name</label>
-      <input id="input-autocomplete-cc-additional-name" name="autocomplete-cc-additional-name" autocomplete="cc-additional-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-cc-additional-name" name="autocomplete-cc-additional-name" autocomplete="cc-additional-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-cc-family-name">CC Family Name</label>
-      <input id="input-autocomplete-cc-family-name" name="autocomplete-cc-family-name" autocomplete="cc-family-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-cc-family-name" name="autocomplete-cc-family-name" autocomplete="cc-family-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-cc-number">CC Number</label>
-      <input novalidate id="input-autocomplete-cc-number" name="autocomplete-cc-number" pattern="\d*" autocomplete="cc-number" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-number" name="autocomplete-cc-number" pattern="\d*" autocomplete="cc-number" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-exp">CC Exp</label>
-      <input novalidate id="input-autocomplete-cc-exp" name="autocomplete-cc-exp" pattern="\d*" autocomplete="cc-exp" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-exp" name="autocomplete-cc-exp" pattern="\d*" autocomplete="cc-exp" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-exp-month">CC Exp Month</label>
-      <input novalidate id="input-autocomplete-cc-exp-month" name="autocomplete-cc-exp-month" pattern="\d*" autocomplete="cc-exp-month" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-exp-month" name="autocomplete-cc-exp-month" pattern="\d*" autocomplete="cc-exp-month" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-exp-year">CC Exp Year</label>
-      <input novalidate id="input-autocomplete-cc-exp-year" name="autocomplete-cc-exp-year" pattern="\d*" autocomplete="cc-exp-year" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-exp-year" name="autocomplete-cc-exp-year" pattern="\d*" autocomplete="cc-exp-year" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-csc">CC CSC (Security code)</label>
-      <input novalidate id="input-autocomplete-cc-csc" name="autocomplete-cc-csc" pattern="\d*" autocomplete="cc-csc" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-csc" name="autocomplete-cc-csc" pattern="\d*" autocomplete="cc-csc" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-type">CC Type (Visa, American Express, etc.)</label>
-      <input id="input-autocomplete-cc-type" name="autocomplete-cc-type" autocomplete="cc-type" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-cc-type" name="autocomplete-cc-type" autocomplete="cc-type" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-transaction-currency">Transaction Currency</label>
-      <input id="input-autocomplete-transaction-currency" name="autocomplete-transaction-currency" autocomplete="transaction-currency" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-transaction-currency" name="autocomplete-transaction-currency" autocomplete="transaction-currency" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-transaction-amount" >Transaction Amount</label>
-      <input id="input-autocomplete-transaction-amount" name="autocomplete-transaction-amount" pattern="\d*" autocomplete="transaction-amount" type="number" />
+      <input id="input-autocomplete-transaction-amount" name="autocomplete-transaction-amount" pattern="\d*" autocomplete="transaction-amount" dir="auto" type="number" />
 
       <label for="input-autocomplete-language">Language (Valid BCP 47 language tag)</label>
-      <input id="input-autocomplete-language" name="autocomplete-language" autocomplete="language" autocapitalize="on" autocorrect="off" type="text" />
+      <input id="input-autocomplete-language" name="autocomplete-language" autocomplete="language" autocapitalize="on" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-bday">Bday</label>
-      <input id="input-autocomplete-bday" name="autocomplete-bday" autocomplete="bday" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-bday" name="autocomplete-bday" autocomplete="bday" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-bday-day">Bday-day</label>
-      <input id="input-autocomplete-bday-day" name="autocomplete-bday-day" pattern="\d*" autocomplete="bday-day" type="tel" />
+      <input id="input-autocomplete-bday-day" name="autocomplete-bday-day" pattern="\d*" autocomplete="bday-day" dir="auto" type="tel" />
 
       <label for="input-autocomplete-bday-month">Bday-month</label>
-      <input id="input-autocomplete-bday-month" name="autocomplete-bday-month" pattern="\d*" autocomplete="bday-month" type="tel" />
+      <input id="input-autocomplete-bday-month" name="autocomplete-bday-month" pattern="\d*" autocomplete="bday-month" dir="auto" type="tel" />
 
       <label for="input-autocomplete-bday-year">Bday-year</label>
-      <input id="input-autocomplete-bday-year" name="autocomplete-bday-year" pattern="\d*" autocomplete="bday-year" type="tel" />
+      <input id="input-autocomplete-bday-year" name="autocomplete-bday-year" pattern="\d*" autocomplete="bday-year" dir="auto" type="tel" />
 
       <label for="input-autocomplete-sex">Sex (Gender identity; free-form text, no newlines)</label>
-      <input id="input-autocomplete-sex" name="autocomplete-sex" autocomplete="sex" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-sex" name="autocomplete-sex" autocomplete="sex" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-url">Autocomplete URL</label>
-      <input id="input-autocomplete-url" name="autocomplete-url" autocomplete="url" autocapitalize="off" autocorrect="off" spellcheck="false" type="url" />
+      <input id="input-autocomplete-url" name="autocomplete-url" autocomplete="url" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="url" />
 
       <label for="input-one-time-code">One-time Code</label>
-      <input id="input-one-time-code" name="one-time-code" autocomplete="one-time-code" autocapitalize="off" autocorrect="off" spellcheck="false" type="number" />
+      <input id="input-one-time-code" name="one-time-code" autocomplete="one-time-code" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="number" />
 
       <label for="input-autocomplete-photo">Photo</label>
       <input id="input-autocomplete-photo" name="autocomplete-photo" autocomplete="photo" type="file" />

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "homepage": "https://github.com/ericwbailey/accessible-html-content-patterns",
   "version": "2.0.4",
   "license": "MIT",
-  "author": "Eric Bailey <eric.w.bailey@gmail.com> (http://ericwbailey.design/)",
-  "contributors": "Scott Doxey <hello@scottdoxey.com> (https://www.scottdoxey.com/)",
+  "author": "Eric Bailey <eric.w.bailey@gmail.com> (http://ericwbailey.website/)",
+  "contributors": [
+    "Scott Doxey <hello@scottdoxey.com> (https://www.scottdoxey.com/)"
+  ],
   "main": "docs/index.html",
   "repository": {
     "type": "git",

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -393,124 +393,123 @@
       </legend>
 
       <label for="input-autocomplete-on">On (Browser automatically completes)</label>
-      <input id="input-autocomplete-on" name="autocomplete-on" autocomplete="on" type="text" />
+      <input id="input-autocomplete-on" name="autocomplete-on" autocomplete="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-name">Name (Full name)</label>
-      <input id="input-autocomplete-name" name="autocomplete-name" autocomplete="name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-name" name="autocomplete-name" autocomplete="name" autocorrect="off" dir="auto" type="text" />
 
 
       <label for="input-autocomplete-honorific-prefix">Honorific Prefix (Mr., Ms., Dr., etc.)</label>
-      <input id="input-autocomplete-honorific-prefix" name="autocomplete-honorific-prefix" autocomplete="honorific-prefix" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-honorific-prefix" name="autocomplete-honorific-prefix" autocomplete="honorific-prefix" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-additional-name">Additional Name</label>
-      <input id="input-autocomplete-additional-name" name="autocomplete-additional-name" autocomplete="additional-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-additional-name" name="autocomplete-additional-name" autocomplete="additional-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-family-name">Family Name</label>
-      <input id="input-autocomplete-family-name" name="autocomplete-family-name" autocomplete="family-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-family-name" name="autocomplete-family-name" autocomplete="family-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-honorific-suffix">Honorific Suffix (Jr., II, etc.)</label>
-      <input id="input-autocomplete-honorific-suffix" name="autocomplete-honorific-suffix" autocomplete="honorific-suffix" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-honorific-suffix" name="autocomplete-honorific-suffix" autocomplete="honorific-suffix" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-nickname">Nickname</label>
-      <input id="input-autocomplete-nickname" name="autocomplete-nickname" autocomplete="nickname" autocorrect="off" type="text" />
+      <input id="input-autocomplete-nickname" name="autocomplete-nickname" autocomplete="nickname" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-email">Autocomplete Email</label>
-      <input id="input-autocomplete-email" name="autocomplete-email" autocomplete="email" autocapitalize="off" autocorrect="off" spellcheck="false" type="text" />
+      <input id="input-autocomplete-email" name="autocomplete-email" autocomplete="email" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="text" />
 
       <label for="input-autocomplete-username">Username</label>
-      <input id="input-autocomplete-username" name="autocomplete-username" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" type="text" />
+      <input id="input-autocomplete-username" name="autocomplete-username" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="text" />
 
       <label for="input-autocomplete-new-password">New Password</label>
-      <input id="input-autocomplete-new-password" name="autocomplete-new-password" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false" type="text" />
+      <input id="input-autocomplete-new-password" name="autocomplete-new-password" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="text" />
 
       <label for="input-autocomplete-current-password">Current Password</label>
-      <input id="input-autocomplete-current-password" name="autocomplete-current-password" autocomplete="current-password" autocapitalize="off" autocorrect="off" spellcheck="false" type="text" />
+      <input id="input-autocomplete-current-password" name="autocomplete-current-password" autocomplete="current-password" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="text" />
 
       <label for="input-autocomplete-organization-title">Organization Title</label>
-      <input id="input-autocomplete-organization-title" name="autocomplete-organization-title" autocomplete="organization-title" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-organization-title" name="autocomplete-organization-title" autocomplete="organization-title" autocapitalize="on" dir="auto" type="text" />
 
 
       <label for="input-autocomplete-organization">Organization</label>
-      <input id="input-autocomplete-organization" name="autocomplete-organization" autocomplete="organization" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-organization" name="autocomplete-organization" autocomplete="organization" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-street-address">Street Address</label>
-      <input id="input-autocomplete-street-address" name="autocomplete-street-address" autocomplete="shipping street-address" autocorrect="off" type="text" />
+      <input id="input-autocomplete-street-address" name="autocomplete-street-address" autocomplete="shipping street-address" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-address-line1">Address Line 1 (Can use address-line1-3)</label>
-      <input id="input-autocomplete-address-line1" name="autocomplete-address-line1" autocomplete="address-line1" autocorrect="off" type="text" />
+      <input id="input-autocomplete-address-line1" name="autocomplete-address-line1" autocomplete="address-line1" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-address-level4">Address Level 4 (Can use address-level4-1)</label>
-      <input id="input-autocomplete-address-level4" name="autocomplete-address-level4" autocomplete="address-level4" autocorrect="off" type="text" />
+      <input id="input-autocomplete-address-level4" name="autocomplete-address-level4" autocomplete="address-level4" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-country">Country</label>
-      <input id="input-autocomplete-country" name="autocomplete-country" autocomplete="country" type="text" />
+      <input id="input-autocomplete-country" name="autocomplete-country" autocomplete="country" dir="auto" type="text" />
 
       <label for="input-autocomplete-country-name">Country Name</label>
-      <input id="input-autocomplete-country-name" name="autocomplete-country-name" autocomplete="country-name" type="text" />
-
+      <input id="input-autocomplete-country-name" name="autocomplete-country-name" autocomplete="country-name" dir="auto" type="text" />
 
       <label for="input-autocomplete-postal-code">Postal Code</label>
-      <input novalidate id="input-autocomplete-postal-code" name="autocomplete-postal-code" autocomplete="shipping postal-code" autocorrect="off" type="number" />
+      <input novalidate id="input-autocomplete-postal-code" name="autocomplete-postal-code" autocomplete="shipping postal-code" autocorrect="off" dir="auto" type="number" />
 
       <label for="input-autocomplete-cc-name">CC Name (Full name as given on the payment instrument)</label>
-      <input id="input-autocomplete-cc-name" name="autocomplete-cc-name" autocomplete="cc-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-cc-name" name="autocomplete-cc-name" autocomplete="cc-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-cc-given-name">CC Given Name</label>
-      <input id="input-autocomplete-cc-given-name" name="autocomplete-cc-given-name" autocomplete="cc-given-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-cc-given-name" name="autocomplete-cc-given-name" autocomplete="cc-given-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-cc-additional-name">CC Additional Name</label>
-      <input id="input-autocomplete-cc-additional-name" name="autocomplete-cc-additional-name" autocomplete="cc-additional-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-cc-additional-name" name="autocomplete-cc-additional-name" autocomplete="cc-additional-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-cc-family-name">CC Family Name</label>
-      <input id="input-autocomplete-cc-family-name" name="autocomplete-cc-family-name" autocomplete="cc-family-name" autocorrect="off" type="text" />
+      <input id="input-autocomplete-cc-family-name" name="autocomplete-cc-family-name" autocomplete="cc-family-name" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-cc-number">CC Number</label>
-      <input novalidate id="input-autocomplete-cc-number" name="autocomplete-cc-number" pattern="\d*" autocomplete="cc-number" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-number" name="autocomplete-cc-number" pattern="\d*" autocomplete="cc-number" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-exp">CC Exp</label>
-      <input novalidate id="input-autocomplete-cc-exp" name="autocomplete-cc-exp" pattern="\d*" autocomplete="cc-exp" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-exp" name="autocomplete-cc-exp" pattern="\d*" autocomplete="cc-exp" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-exp-month">CC Exp Month</label>
-      <input novalidate id="input-autocomplete-cc-exp-month" name="autocomplete-cc-exp-month" pattern="\d*" autocomplete="cc-exp-month" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-exp-month" name="autocomplete-cc-exp-month" pattern="\d*" autocomplete="cc-exp-month" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-exp-year">CC Exp Year</label>
-      <input novalidate id="input-autocomplete-cc-exp-year" name="autocomplete-cc-exp-year" pattern="\d*" autocomplete="cc-exp-year" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-exp-year" name="autocomplete-cc-exp-year" pattern="\d*" autocomplete="cc-exp-year" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-csc">CC CSC (Security code)</label>
-      <input novalidate id="input-autocomplete-cc-csc" name="autocomplete-cc-csc" pattern="\d*" autocomplete="cc-csc" autocorrect="off" type="tel" />
+      <input novalidate id="input-autocomplete-cc-csc" name="autocomplete-cc-csc" pattern="\d*" autocomplete="cc-csc" autocorrect="off" dir="auto" type="tel" />
 
       <label for="input-autocomplete-cc-type">CC Type (Visa, American Express, etc.)</label>
-      <input id="input-autocomplete-cc-type" name="autocomplete-cc-type" autocomplete="cc-type" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-cc-type" name="autocomplete-cc-type" autocomplete="cc-type" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-transaction-currency">Transaction Currency</label>
-      <input id="input-autocomplete-transaction-currency" name="autocomplete-transaction-currency" autocomplete="transaction-currency" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-transaction-currency" name="autocomplete-transaction-currency" autocomplete="transaction-currency" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-transaction-amount" >Transaction Amount</label>
-      <input id="input-autocomplete-transaction-amount" name="autocomplete-transaction-amount" pattern="\d*" autocomplete="transaction-amount" type="number" />
+      <input id="input-autocomplete-transaction-amount" name="autocomplete-transaction-amount" pattern="\d*" autocomplete="transaction-amount" dir="auto" type="number" />
 
       <label for="input-autocomplete-language">Language (Valid BCP 47 language tag)</label>
-      <input id="input-autocomplete-language" name="autocomplete-language" autocomplete="language" autocapitalize="on" autocorrect="off" type="text" />
+      <input id="input-autocomplete-language" name="autocomplete-language" autocomplete="language" autocapitalize="on" autocorrect="off" dir="auto" type="text" />
 
       <label for="input-autocomplete-bday">Bday</label>
-      <input id="input-autocomplete-bday" name="autocomplete-bday" autocomplete="bday" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-bday" name="autocomplete-bday" autocomplete="bday" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-bday-day">Bday-day</label>
-      <input id="input-autocomplete-bday-day" name="autocomplete-bday-day" pattern="\d*" autocomplete="bday-day" type="tel" />
+      <input id="input-autocomplete-bday-day" name="autocomplete-bday-day" pattern="\d*" autocomplete="bday-day" dir="auto" type="tel" />
 
       <label for="input-autocomplete-bday-month">Bday-month</label>
-      <input id="input-autocomplete-bday-month" name="autocomplete-bday-month" pattern="\d*" autocomplete="bday-month" type="tel" />
+      <input id="input-autocomplete-bday-month" name="autocomplete-bday-month" pattern="\d*" autocomplete="bday-month" dir="auto" type="tel" />
 
       <label for="input-autocomplete-bday-year">Bday-year</label>
-      <input id="input-autocomplete-bday-year" name="autocomplete-bday-year" pattern="\d*" autocomplete="bday-year" type="tel" />
+      <input id="input-autocomplete-bday-year" name="autocomplete-bday-year" pattern="\d*" autocomplete="bday-year" dir="auto" type="tel" />
 
       <label for="input-autocomplete-sex">Sex (Gender identity; free-form text, no newlines)</label>
-      <input id="input-autocomplete-sex" name="autocomplete-sex" autocomplete="sex" autocapitalize="on" type="text" />
+      <input id="input-autocomplete-sex" name="autocomplete-sex" autocomplete="sex" autocapitalize="on" dir="auto" type="text" />
 
       <label for="input-autocomplete-url">Autocomplete URL</label>
-      <input id="input-autocomplete-url" name="autocomplete-url" autocomplete="url" autocapitalize="off" autocorrect="off" spellcheck="false" type="url" />
+      <input id="input-autocomplete-url" name="autocomplete-url" autocomplete="url" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="url" />
 
       <label for="input-one-time-code">One-time Code</label>
-      <input id="input-one-time-code" name="one-time-code" autocomplete="one-time-code" autocapitalize="off" autocorrect="off" spellcheck="false" type="number" />
+      <input id="input-one-time-code" name="one-time-code" autocomplete="one-time-code" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="number" />
 
       <label for="input-autocomplete-photo">Photo</label>
       <input id="input-autocomplete-photo" name="autocomplete-photo" autocomplete="photo" type="file" />

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -378,9 +378,10 @@
         </button>
 
         <h5 id="notes-button-states-and-validation">Notes:</h5>
-        <p>
-          <small>Use <code translate="no">:hover</code>, <code translate="no">:focus</code>, and <code translate="no">:active</code> selectors to control the other button states. Learn more about <a rel="external noopener" href="https://css-tricks.com/user-facing-state/">semantically managing state</a> and using <a rel="external noopener" href="https://medium.com/eightshapes-llc/buttons-in-design-systems-eac3acf7e23#.b1p96hsrw"><cite>Buttons in Design Systems</cite></a>.</small>
-        </p>
+        <ul>
+          <li><small>Use <code translate="no">:hover</code>, <code translate="no">:focus</code>, and <code translate="no">:active</code> selectors to control the other button states. Learn more about <a rel="external noopener" href="https://css-tricks.com/user-facing-state/">semantically managing state</a> and using <a rel="external noopener" href="https://medium.com/eightshapes-llc/buttons-in-design-systems-eac3acf7e23#.b1p96hsrw"><cite>Buttons in Design Systems</cite></a>.</small></li>
+          <li><small>Other <a rel="external noopener" href="https://ericwbailey.website/published/all-the-user-facing-states/">user-facing states</a> may also apply</small></li>
+        </ul>
       </div>
       <!-- End of #subsection-button-states -->
     </fieldset>

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -72,6 +72,9 @@
       <h4 id="notes-text-input">Notes:</h4>
       <ul>
         <li>
+          <small>Add <code translate="no">dir="auto"</code> to <a rel="external noopener" href="https://mough.xyz/312/psa-add-dir-auto-to-your-inputs-and-textareas">inputs that accept text</a>.</small>
+        </li>
+        <li>
           <small>Avoid nesting <code translate="no">input</code> elements inside of <code translate="no">label</code> elements for better support for <a rel="external noopener" href="https://www.nuance.com/dragon.html">Dragon Speech Recognition</a>.</small>
         </li>
         <li>
@@ -379,8 +382,12 @@
 
         <h5 id="notes-button-states-and-validation">Notes:</h5>
         <ul>
-          <li><small>Use <code translate="no">:hover</code>, <code translate="no">:focus</code>, and <code translate="no">:active</code> selectors to control the other button states. Learn more about <a rel="external noopener" href="https://css-tricks.com/user-facing-state/">semantically managing state</a> and using <a rel="external noopener" href="https://medium.com/eightshapes-llc/buttons-in-design-systems-eac3acf7e23#.b1p96hsrw"><cite>Buttons in Design Systems</cite></a>.</small></li>
-          <li><small>Other <a rel="external noopener" href="https://ericwbailey.website/published/all-the-user-facing-states/">user-facing states</a> may also apply</small></li>
+          <li>
+            <small>Use <code translate="no">:hover</code>, <code translate="no">:focus</code>, and <code translate="no">:active</code> selectors to control the other button states. Learn more about <a rel="external noopener" href="https://css-tricks.com/user-facing-state/">semantically managing state</a> and using <a rel="external noopener" href="https://medium.com/eightshapes-llc/buttons-in-design-systems-eac3acf7e23#.b1p96hsrw"><cite>Buttons in Design Systems</cite></a>.</small>
+          </li>
+          <li>
+            <small>Other <a rel="external noopener" href="https://ericwbailey.website/published/all-the-user-facing-states/">user-facing states</a> may also apply.</small>
+          </li>
         </ul>
       </div>
       <!-- End of #subsection-button-states -->

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -332,37 +332,37 @@
         <h4 id="subtitle-input">Input</h4>
 
         <label for="input-required">Required</label>
-        <input required id="input-required" name="required" type="text" />
+        <input required id="input-required" name="required" dir="auto" type="text" />
 
         <label for="input-readonly">Readonly</label>
-        <input readonly value="Read Only" id="input-readonly" name="readonly" type="text" />
+        <input readonly value="Read Only" id="input-readonly" name="readonly" dir="auto" type="text" />
 
         <label for="input-loading">Loading</label>
-        <input id="input-loading" name="loading" aria-busy="true" data-input-state="loading" type="text" />
+        <input id="input-loading" name="loading" aria-busy="true" data-input-state="loading" dir="auto" type="text" />
 
         <label for="input-disabled">Disabled</label>
-        <input disabled id="input-disabled" name="disabled" type="text" />
+        <input disabled id="input-disabled" name="disabled" dir="auto" type="text" />
 
         <label for="input-valid">Valid</label>
-        <input id="input-valid" name="valid" aria-invalid="false" type="text" />
+        <input id="input-valid" name="valid" aria-invalid="false" dir="auto" type="text" />
 
         <label for="input-invalid">Invalid</label>
-        <input id="input-invalid" name="invalid" aria-invalid="true" type="text" />
+        <input id="input-invalid" name="invalid" aria-invalid="true" dir="auto" type="text" />
 
         <label for="input-warning">Warning</label>
-        <input id="input-warning" name="warning" data-input-state="warning" type="text" />
+        <input id="input-warning" name="warning" data-input-state="warning" dir="auto" type="text" />
 
         <label for="input-search-with-autosave">Search with Autosave</label>
-        <input autosave id="input-search-with-autosave" name="search-with-autosave" type="search" />
+        <input autosave id="input-search-with-autosave" name="search-with-autosave" dir="auto" type="search" />
 
         <label for="input-pattern">Input with Pattern Validation</label>
-        <input pattern="[0-9]{13,16}" id="input-pattern" name="pattern" type="number" />
+        <input pattern="[0-9]{13,16}" id="input-pattern" name="pattern" dir="auto" type="number" />
 
         <label for="input-minlength">Minlength</label>
-        <input id="input-minlength" name="minlength" minlength="5" type="number" />
+        <input id="input-minlength" name="minlength" minlength="5" dir="auto" type="number" />
 
         <label for="input-maxlength">Maxlength</label>
-        <input id="input-maxlength" name="maxlength" maxlength="10" type="number" />
+        <input id="input-maxlength" name="maxlength" maxlength="10" dir="auto" type="number" />
       </div>
       <!-- End of #subsection-input -->
 

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -29,8 +29,10 @@
       <label for="input-number" >Number</label>
       <input id="input-number" type="text" inputmode="numeric" dir="auto" pattern="[0-9]*" />
 
-      <label for="input-search">Search</label>
-      <input id="input-search" name="search" spellcheck="false" dir="auto" type="search" />
+      <search>
+        <label for="input-search">Search</label>
+        <input id="input-search" name="search" spellcheck="false" dir="auto" type="search" />
+      </search>
 
       <label for="input-date">Date</label>
       <input id="input-date" name="date" type="date" />
@@ -355,8 +357,10 @@
         <label for="input-warning">Warning</label>
         <input id="input-warning" name="warning" data-input-state="warning" dir="auto" type="text" />
 
-        <label for="input-search-with-autosave">Search with Autosave</label>
-        <input autosave id="input-search-with-autosave" name="search-with-autosave" dir="auto" type="search" />
+        <search>
+          <label for="input-search-with-autosave">Search with Autosave</label>
+          <input autosave id="input-search-with-autosave" name="search-with-autosave" dir="auto" type="search" />
+        </search>
 
         <label for="input-pattern">Input with Pattern Validation</label>
         <input pattern="[0-9]{13,16}" id="input-pattern" name="pattern" dir="auto" type="number" />

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -9,28 +9,28 @@
       </legend>
 
       <label for="input-text">Text</label>
-      <input id="input-text" name="text" type="text" />
+      <input id="input-text" name="text" dir="auto" type="text" />
 
       <label for="input-text-with-placeholder">Text with Placeholder</label>
-      <input id="input-text-with-placeholder" name="placeholder" placeholder="Placeholder" type="text" />
+      <input id="input-text-with-placeholder" name="placeholder" placeholder="Placeholder" dir="auto" type="text" />
 
       <label for="input-email">Email</label>
-      <input id="input-email" name="email" placeholder="name@example.com" autocapitalize="off" autocorrect="off" spellcheck="false" type="email" />
+      <input id="input-email" name="email" placeholder="name@example.com" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="email" />
 
       <label for="input-password">Password</label>
-      <input id="input-password" name="password" autocapitalize="off" autocorrect="off" spellcheck="false" type="password" />
+      <input id="input-password" name="password" autocapitalize="off" autocorrect="off" spellcheck="false" dir="auto" type="password" />
 
       <label for="input-url">URL</label>
-      <input id="input-url" name="url" autocapitalize="off" spellcheck="false" type="url" />
+      <input id="input-url" name="url" autocapitalize="off" spellcheck="false" dir="auto" type="url" />
 
       <label for="input-telephone">Telephone</label>
-      <input id="input-telephone" name="telephone" autocorrect="off" autocomplete="tel" spellcheck="false" type="tel" />
+      <input id="input-telephone" name="telephone" autocorrect="off" autocomplete="tel" spellcheck="false" dir="auto" type="tel" />
 
       <label for="input-number" >Number</label>
-      <input id="input-number" type="text" inputmode="numeric" pattern="[0-9]*" />
+      <input id="input-number" type="text" inputmode="numeric" dir="auto" pattern="[0-9]*" />
 
       <label for="input-search">Search</label>
-      <input id="input-search" name="search" spellcheck="false" type="search" />
+      <input id="input-search" name="search" spellcheck="false" dir="auto" type="search" />
 
       <label for="input-date">Date</label>
       <input id="input-date" name="date" type="date" />
@@ -48,7 +48,7 @@
       <input id="input-week" name="week" type="week" />
 
       <label for="input-datalist">Datalist</label>
-      <input list="dog-breeds" id="input-datalist" name="datalist" type="text">
+      <input list="dog-breeds" id="input-datalist" name="datalist" dir="auto" type="text">
       <datalist id="dog-breeds">
         <option value="Beagles"></option>
         <option value="Boxers"></option>


### PR DESCRIPTION
This PR:

- Wraps `input` elements with a `type="search"` in the `search` element.
- Adds `dir="auto"` to input elements.
- Updates info in `package.json`.