### PR TITLE
Add note about `maxlength` support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -833,6 +833,9 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
         <li>
           <small>Safari's password AutoFill feature can be <a rel="external noopener" href="https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules">configured with custom password criteria</a>.</small>
         </li>
+        <li>
+          <small><code translate="no">maxlength</code>'s presence is not announced by screen readers.</small>
+        </li>
       </ul>
     </fieldset>
     <!-- End of #subsection-text-input -->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "accessible-html-content-patterns",
   "description": "A collection of the full HTML5 Doctor Element Index as well as common markup patterns for quick reference.",
   "homepage": "https://github.com/ericwbailey/accessible-html-content-patterns",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "license": "MIT",
   "author": "Eric Bailey <eric.w.bailey@gmail.com> (http://ericwbailey.website/)",
   "contributors": [

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -91,6 +91,9 @@
         <li>
           <small>Safari's password AutoFill feature can be <a rel="external noopener" href="https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules">configured with custom password criteria</a>.</small>
         </li>
+        <li>
+          <small><code translate="no">maxlength</code>'s presence is not announced by screen readers.</small>
+        </li>
       </ul>
     </fieldset>
     <!-- End of #subsection-text-input -->


### PR DESCRIPTION
This PR adds a note about `maxlength` not being announced by screenreaders.