### PR TITLE
Fix mixed content errors for placeholder images

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -608,7 +608,7 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
   <!-- Start of #subsection-broken-image -->
   <h3 id="subsection-lazy-loaded-image">Lazy-loaded Image</h3>
   <img
-    src="http://dummyimage.com/500x500?text=Lazy-Loaded+Image+Example"
+    src="https://dummyimage.com/500x500?text=Lazy-Loaded+Image+Example"
     loading="lazy"
     decoding="async"
     width="500"
@@ -627,7 +627,7 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
   <h3 id="subsection-figure-with-caption">Figure with Caption</h3>
   <figure>
     <img
-      src="http://dummyimage.com/400x250?text=Figure+Example"
+      src="https://dummyimage.com/400x250?text=Figure+Example"
       alt="Figure Example" />
     <figcaption>
       An example figure caption.
@@ -677,11 +677,11 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
   <picture>
     <source
       media="(min-width: 40em)"
-      srcset="http://dummyimage.com/800x450/7ED321/ffffff/?text=1x+Source+w/Breakpoint+Example 1x,
-              http://dummyimage.com/800x600/7ED321/ffffff/?text=2x+Source+w/Breakpoint+Example 2x" />
+      srcset="https://dummyimage.com/800x450/7ED321/ffffff/?text=1x+Source+w/Breakpoint+Example 1x,
+              https://dummyimage.com/800x600/7ED321/ffffff/?text=2x+Source+w/Breakpoint+Example 2x" />
     <source
-      srcset="http://dummyimage.com/500x250/F5A623/ffffff/?text=1x+Source+Example 1x,
-              http://dummyimage.com/500x250/F5A623/ffffff/?text=2x+Source+Example 2x" />
+      srcset="https://dummyimage.com/500x250/F5A623/ffffff/?text=1x+Source+Example 1x,
+              https://dummyimage.com/500x250/F5A623/ffffff/?text=2x+Source+Example 2x" />
     <img
       src="https://dummyimage.com/600x400?text==Img+Fallback"
       alt="Picture Element" />
@@ -691,9 +691,9 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
   <!-- Start of #subsection-image-with-srcset-and-sizes -->
   <h3 id="subsection-image-with-srcset-and-sizes">Image with Srcset and Sizes</h3>
   <img
-    srcset="http://dummyimage.com/1024x768/7ED321/ffffff/?text=Large 1024w,
-            http://dummyimage.com/1024x768/F5A623/ffffff/?text=Medium 640w,
-            http://dummyimage.com/320x240/50E3C2/ffffff/?text=Small 320w"
+    srcset="https://dummyimage.com/1024x768/7ED321/ffffff/?text=Large 1024w,
+            https://dummyimage.com/1024x768/F5A623/ffffff/?text=Medium 640w,
+            https://dummyimage.com/320x240/50E3C2/ffffff/?text=Small 320w"
     sizes="(min-width: 36em) 50vw, 100vw"
     src="https://dummyimage.com/600x400?text==Img+Fallback"
     alt="Image with Srcset and Sizes Example" />
@@ -738,7 +738,7 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
   <h3 id="subsection-video">Video</h3>
   <video
     controls
-    poster="http://dummyimage.com/854x480?text=Video+Poster">
+    poster="https://dummyimage.com/854x480?text=Video+Poster">
     <source
       src="http://clips.vorwaerts-gmbh.de/VfE_html5.mp4"
       type="video/mp4" />

--- a/partials/section.embedded.hbs
+++ b/partials/section.embedded.hbs
@@ -12,7 +12,7 @@
   <!-- Start of #subsection-broken-image -->
   <h3 id="subsection-lazy-loaded-image">Lazy-loaded Image</h3>
   <img
-    src="http://dummyimage.com/500x500?text=Lazy-Loaded+Image+Example"
+    src="https://dummyimage.com/500x500?text=Lazy-Loaded+Image+Example"
     loading="lazy"
     decoding="async"
     width="500"
@@ -31,7 +31,7 @@
   <h3 id="subsection-figure-with-caption">Figure with Caption</h3>
   <figure>
     <img
-      src="http://dummyimage.com/400x250?text=Figure+Example"
+      src="https://dummyimage.com/400x250?text=Figure+Example"
       alt="Figure Example" />
     <figcaption>
       An example figure caption.
@@ -81,11 +81,11 @@
   <picture>
     <source
       media="(min-width: 40em)"
-      srcset="http://dummyimage.com/800x450/7ED321/ffffff/?text=1x+Source+w/Breakpoint+Example 1x,
-              http://dummyimage.com/800x600/7ED321/ffffff/?text=2x+Source+w/Breakpoint+Example 2x" />
+      srcset="https://dummyimage.com/800x450/7ED321/ffffff/?text=1x+Source+w/Breakpoint+Example 1x,
+              https://dummyimage.com/800x600/7ED321/ffffff/?text=2x+Source+w/Breakpoint+Example 2x" />
     <source
-      srcset="http://dummyimage.com/500x250/F5A623/ffffff/?text=1x+Source+Example 1x,
-              http://dummyimage.com/500x250/F5A623/ffffff/?text=2x+Source+Example 2x" />
+      srcset="https://dummyimage.com/500x250/F5A623/ffffff/?text=1x+Source+Example 1x,
+              https://dummyimage.com/500x250/F5A623/ffffff/?text=2x+Source+Example 2x" />
     <img
       src="https://dummyimage.com/600x400?text==Img+Fallback"
       alt="Picture Element" />
@@ -95,9 +95,9 @@
   <!-- Start of #subsection-image-with-srcset-and-sizes -->
   <h3 id="subsection-image-with-srcset-and-sizes">Image with Srcset and Sizes</h3>
   <img
-    srcset="http://dummyimage.com/1024x768/7ED321/ffffff/?text=Large 1024w,
-            http://dummyimage.com/1024x768/F5A623/ffffff/?text=Medium 640w,
-            http://dummyimage.com/320x240/50E3C2/ffffff/?text=Small 320w"
+    srcset="https://dummyimage.com/1024x768/7ED321/ffffff/?text=Large 1024w,
+            https://dummyimage.com/1024x768/F5A623/ffffff/?text=Medium 640w,
+            https://dummyimage.com/320x240/50E3C2/ffffff/?text=Small 320w"
     sizes="(min-width: 36em) 50vw, 100vw"
     src="https://dummyimage.com/600x400?text==Img+Fallback"
     alt="Image with Srcset and Sizes Example" />
@@ -142,7 +142,7 @@
   <h3 id="subsection-video">Video</h3>
   <video
     controls
-    poster="http://dummyimage.com/854x480?text=Video+Poster">
+    poster="https://dummyimage.com/854x480?text=Video+Poster">
     <source
       src="http://clips.vorwaerts-gmbh.de/VfE_html5.mp4"
       type="video/mp4" />


### PR DESCRIPTION
# Fix mixed content errors for placeholder images

## What does this Pull Request do?

Fixes https://github.com/ericwbailey/accessible-html-content-patterns/issues/26 

## Where should the reviewer start?

Just review the modified template `section.embedded.hbs` and then test the compiled output.

## How should this be manually tested?

View the updated `docs/index.html` over an SSL connection and check for any mixed content errors (e.g., Chrome DevTools Network tab).

## Any background context you want to provide?

The mixed content error was preventing the affected placeholder images from being displayed.

## What are the relevant tickets?

https://github.com/ericwbailey/accessible-html-content-patterns/issues/26

## Applicable screenshots

Bug in production version. 

<img width="1255" height="331" alt="Mixed content errors highlighted in a screenshot of Chrome DevTools Network view" src="https://github.com/user-attachments/assets/aa265fd1-9b11-4ef2-b732-bb889a579b2e" />

## Additional questions

N/A
