### PR TITLE
Add references for `enterKeyHint` and the `download` attribute

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -271,8 +271,15 @@
     </a>
     <h4 id="notes-lists">Notes:</h4>
     <ul>
-      <li><small><a href="https://werd.io/2024/browsers-imply-noopener-for-links-in-new-tab" rel="external noopener">Browsers will imply <code translate="no">noopener</code></a> for links that open in a new window/tab.</small></li>
-      <li><small>Anchor element <code translate="no">href</code> values can <a href="https://blog.jim-nielsen.com/2025/href-value-possibilities/">perform specific functionality</a>.</small></li>
+      <li>
+        <small><a href="https://werd.io/2024/browsers-imply-noopener-for-links-in-new-tab" rel="external noopener">Browsers will imply <code translate="no">noopener</code></a> for links that open in a new window/tab.</small>
+      </li>
+      <li>
+        <small>Anchor element <code translate="no">href</code> values can <a href="https://blog.jim-nielsen.com/2025/href-value-possibilities/">perform specific functionality</a>.</small>
+      </li>
+      <li>
+        <small>The <code translate="no">download</code> attribute will <a rel="external noopener" href="https://macarthur.me/posts/trigger-cross-origin-download/">not automatically work for cross-origin resources</a>.</small>
+      </li>
     </ul>
   </div>
   <!-- End of #subsection-links -->
@@ -916,6 +923,9 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
         </li>
         <li>
           <small>Use <code translate="no">handwriting="true"</code> to allow handwriting input, and <code translate="no">handwriting="false"</code> to disallow it.</small>
+        </li>
+        <li>
+          <small><code translate="no">enterKeyHint</code> allows you to <a rel="external noopener" href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/enterKeyHint">customize the <kbd>Enter</kbd> key on virtual keyboards</a>.</small>
         </li>
       </ul>
     </fieldset>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "accessible-html-content-patterns",
   "description": "A collection of the full HTML5 Doctor Element Index as well as common markup patterns for quick reference.",
   "homepage": "https://github.com/ericwbailey/accessible-html-content-patterns",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "license": "MIT",
   "author": "Eric Bailey <eric.w.bailey@gmail.com> (http://ericwbailey.website/)",
   "contributors": [

--- a/partials/section.forms.hbs
+++ b/partials/section.forms.hbs
@@ -100,6 +100,9 @@
         <li>
           <small>Use <code translate="no">handwriting="true"</code> to allow handwriting input, and <code translate="no">handwriting="false"</code> to disallow it.</small>
         </li>
+        <li>
+          <small><code translate="no">enterKeyHint</code> allows you to <a rel="external noopener" href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/enterKeyHint">customize the <kbd>Enter</kbd> key on virtual keyboards</a>.</small>
+        </li>
       </ul>
     </fieldset>
     <!-- End of #subsection-text-input -->

--- a/partials/section.text-level.hbs
+++ b/partials/section.text-level.hbs
@@ -49,8 +49,15 @@
     </a>
     <h4 id="notes-lists">Notes:</h4>
     <ul>
-      <li><small><a href="https://werd.io/2024/browsers-imply-noopener-for-links-in-new-tab" rel="external noopener">Browsers will imply <code translate="no">noopener</code></a> for links that open in a new window/tab.</small></li>
-      <li><small>Anchor element <code translate="no">href</code> values can <a href="https://blog.jim-nielsen.com/2025/href-value-possibilities/">perform specific functionality</a>.</small></li>
+      <li>
+        <small><a href="https://werd.io/2024/browsers-imply-noopener-for-links-in-new-tab" rel="external noopener">Browsers will imply <code translate="no">noopener</code></a> for links that open in a new window/tab.</small>
+      </li>
+      <li>
+        <small>Anchor element <code translate="no">href</code> values can <a href="https://blog.jim-nielsen.com/2025/href-value-possibilities/">perform specific functionality</a>.</small>
+      </li>
+      <li>
+        <small>The <code translate="no">download</code> attribute will <a rel="external noopener" href="https://macarthur.me/posts/trigger-cross-origin-download/">not automatically work for cross-origin resources</a>.</small>
+      </li>
     </ul>
   </div>
   <!-- End of #subsection-links -->


### PR DESCRIPTION
This PR adds references for enterKeyHint and how the `download` attribute will not work for cross-origin resources.