### PR TITLE
Add note about lazy loading `video` and `audio` content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -739,6 +739,11 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
     Your browser does not support the <code translate="no">&lt;audio&gt;</code> element.
     Please <a rel="external noopener" href="http://browsehappy.com/">consider upgrading your browser</a> or <a download href="http://www.noiseaddicts.com/samples_1w72b820/4353.mp3">download a file</a> for offline listening.
   </audio>
+
+  <h3 id="notes-audio">Notes:</h3>
+  <p>
+    <code translate="no">&lt;video&gt;</code> now supports the <code translate="no">&lt;lazy&gt;</code> attribute.</small>
+  </p>
   <!-- End of #subsection-audio -->
 
   <!-- Start of #subsection-video -->
@@ -765,9 +770,14 @@ drwxr-xr-x 9 eric staff   306 Mar 24 13:36 .git/
   </video>
 
   <h3 id="notes-video">Notes:</h3>
-  <p>
-    <small>Accessibility errors concerning the video's missing audio description should go away once the <code translate="no">&lt;track&gt;</code>'s source is linked to a valid caption file.</small>
-  </p>
+  <ul>
+    <li>
+      <small>Accessibility errors concerning the video's missing audio description should go away once the <code translate="no">&lt;track&gt;</code>'s source is linked to a valid caption file.</small>
+    </li>
+    <li>
+      <code translate="no">&lt;video&gt;</code> now supports the <code translate="no">&lt;lazy&gt;</code> attribute.</small>
+    </li>
+  </ul>
   <!-- End of #subsection-video -->
 
   <!-- Start of #subsection-object -->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "accessible-html-content-patterns",
   "description": "A collection of the full HTML5 Doctor Element Index as well as common markup patterns for quick reference.",
   "homepage": "https://github.com/ericwbailey/accessible-html-content-patterns",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "license": "MIT",
   "author": "Eric Bailey <eric.w.bailey@gmail.com> (http://ericwbailey.website/)",
   "contributors": [

--- a/partials/section.embedded.hbs
+++ b/partials/section.embedded.hbs
@@ -136,6 +136,11 @@
     Your browser does not support the <code translate="no">&lt;audio&gt;</code> element.
     Please <a rel="external noopener" href="http://browsehappy.com/">consider upgrading your browser</a> or <a download href="http://www.noiseaddicts.com/samples_1w72b820/4353.mp3">download a file</a> for offline listening.
   </audio>
+
+  <h3 id="notes-audio">Notes:</h3>
+  <p>
+    <code translate="no">&lt;video&gt;</code> now supports the <code translate="no">&lt;lazy&gt;</code> attribute.</small>
+  </p>
   <!-- End of #subsection-audio -->
 
   <!-- Start of #subsection-video -->
@@ -162,9 +167,14 @@
   </video>
 
   <h3 id="notes-video">Notes:</h3>
-  <p>
-    <small>Accessibility errors concerning the video's missing audio description should go away once the <code translate="no">&lt;track&gt;</code>'s source is linked to a valid caption file.</small>
-  </p>
+  <ul>
+    <li>
+      <small>Accessibility errors concerning the video's missing audio description should go away once the <code translate="no">&lt;track&gt;</code>'s source is linked to a valid caption file.</small>
+    </li>
+    <li>
+      <code translate="no">&lt;video&gt;</code> now supports the <code translate="no">&lt;lazy&gt;</code> attribute.</small>
+    </li>
+  </ul>
   <!-- End of #subsection-video -->
 
   <!-- Start of #subsection-object -->


### PR DESCRIPTION
This PR adds notes about [the addition of support for lazy loading `video` and `audio` sources](https://engineering.squarespace.com/blog/2026/how-to-use-standard-html-video-and-audio-lazy-loading-on-the-web-today).